### PR TITLE
[drone] set deployment update strategy

### DIFF
--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,7 +4,7 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: 1.6.5
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       {{- include "drone.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{ toYaml .Values.updateStrategy | indent 4 }}
   template:
     metadata:
       labels:

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -34,6 +34,8 @@ podAnnotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "80"
 
+updateStrategy: {}
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
This fix failure to upgrade (by switch strategy to `Recreate` when `persistence.enabled` is `true` and PV don't let multiple pod to mount the same volume at the same time

BTW, please publish the updated chart when you merge