### PR TITLE
Add drone-runner Service Account annotations

### DIFF
--- a/charts/drone-runner-kube/templates/rbac.yaml
+++ b/charts/drone-runner-kube/templates/rbac.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "drone-runner-kube.fullname" . }}
+  annotations:
+    {{- toYaml .Values.rbac.serviceAccountAnnotations | nindent 4 }}
   labels:
     {{- include "drone-runner-kube.labels" . | nindent 4 }}
 

--- a/charts/drone-runner-kube/values.yaml
+++ b/charts/drone-runner-kube/values.yaml
@@ -99,6 +99,7 @@ extraSecretNamesForEnvFrom: []
 rbac:
   buildNamespaces:
     - default
+  serviceAccountAnnotations: {}
 
 ## The keys within the "env" map are mounted as environment variables on the Kubernetes runner pod.
 ## See the full reference of Kubernetes runner environment variables here:


### PR DESCRIPTION
If you want to use drone in EKS and assign IAM role with OIDC provider you need to provide IAM role arn in service account annotations. 