### PR TITLE
Allow custom webserver port

### DIFF
--- a/charts/drone/templates/configmap.yaml
+++ b/charts/drone/templates/configmap.yaml
@@ -12,3 +12,6 @@ data:
 {{- range $envKey, $envVal := .Values.env }}
   {{ $envKey | upper }}: {{ $envVal | quote }}
 {{- end }}
+{{- if .Values.port }}
+  DRONE_SERVER_PORT: :{{ .Values.port }}
+{{- end }}

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.port }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -151,6 +151,11 @@ emptyDir:
 extraSecretNamesForEnvFrom: []
 # - my-drone-secrets
 
+# The port for the Drone web server.  Set this to a high port such as 8080 if a
+# custom securityContext (either specified above or in a PodSecurityPolicy)
+# would prevent Drone server from running as root.
+port: 80
+
 ## The keys within the "env" map are mounted as environment variables on the Drone server pod.
 ## See the full reference of Drone server environment variables here:
 ## Ref: https://docs.drone.io/installation/reference/


### PR DESCRIPTION
This PR adds a `port` value to the Helm chart.  The primary use case is to enable binding to high ports to avoid running Drone server as root.