### PR TITLE
Provide for annotations to kubernetes service

### DIFF
--- a/charts/drone/templates/service.yaml
+++ b/charts/drone/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "drone.fullname" . }}
+  annotations:
+    {{ toYaml .Values.service.annotations | nindent 4 }}
   labels:
     {{- include "drone.labels" . | nindent 4 }}
 spec:

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -39,6 +39,7 @@ updateStrategy: {}
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
This change allows the user to provide annotations to the k8s svc for
drone.

In our case, we rely on service annotations to interact with GCP NEGs
via a controller that reads them.

This adds to the templates/service.yaml an optional 'annotations' field
that can be populated by the user, or left empty by default.

This shouldn't be conflaited with the ingress annotations. We
specifically do not use k8s ingress and we should be able to articulate
annotations for either, both, or none of the service/ingress resources.