### PR TITLE
drone Allow configuration of deployment replica count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ lint:
 .PHONY: publish
 publish:
 	@mkdir -p temp docs
-	@helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-	@helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+	@helm repo add stable https://charts.helm.sh/stable
+	@helm repo add incubator https://charts.helm.sh/incubator
 	@helm package -u -d temp charts/drone charts/drone-runner-kube charts/drone-kubernetes-secrets
 	@helm repo index --debug --url=https://charts.drone.io --merge docs/index.yaml temp
 	@mv temp/drone*.tgz docs

--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,7 +4,7 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.1.7
+version: 0.1.9
 appVersion: 1.9.0
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "drone.labels" . | nindent 4 }}
 spec:
   {{/* Drone server is a singleton. */}}
-  replicas: 1
+  replicas: {{ if ge .Values.replicas 1.0 }}1{{ else if lt .Values.replicas 1.0 }}0{{end}}
   selector:
     matchLabels:
       {{- include "drone.selectorLabels" . | nindent 6 }}

--- a/charts/drone/values.schema.json
+++ b/charts/drone/values.schema.json
@@ -7,6 +7,7 @@
     "imagePullSecrets",
     "nameOverride",
     "fullnameOverride",
+	"replicas",
     "podSecurityContext",
     "securityContext",
     "podAnnotations",
@@ -57,6 +58,10 @@
     "fullnameOverride": {
       "$id": "#/properties/fullnameOverride",
       "type": "string"
+    },
+    "replicas": {
+      "$id": "#/properties/replicas",
+      "type": "integer"
     },
     "podSecurityContext": {
       "$id": "#/properties/podSecurityContext",

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -13,6 +13,14 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Drone server is a singleton, but it may be desirable to deploy the helm chart with 
+#  a replica count of 0. A scenario here would be deploying a cold-standby copy of 
+#  drone to a different cluster/region/namespace/etc
+# The 'replicas' value may only be one of '0' or '1'.
+# Numbers greater than 1 will be set to 1
+# Numbers less than 1 will be set to 0
+replicas: 1
+
 # Drone server does not interact with the Kubernetes API server
 automountServiceAccountToken: false
 

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -13,8 +13,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# Drone server is a singleton, but it may be desirable to deploy the helm chart with 
-#  a replica count of 0. A scenario here would be deploying a cold-standby copy of 
+# Drone server is a singleton, but it may be desirable to deploy the helm chart with
+#  a replica count of 0. A scenario here would be deploying a cold-standby copy of
 #  drone to a different cluster/region/namespace/etc
 # The 'replicas' value may only be one of '0' or '1'.
 # Numbers greater than or equal to 1 will be set to 1

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: ""
 #  a replica count of 0. A scenario here would be deploying a cold-standby copy of 
 #  drone to a different cluster/region/namespace/etc
 # The 'replicas' value may only be one of '0' or '1'.
-# Numbers greater than 1 will be set to 1
+# Numbers greater than or equal to 1 will be set to 1
 # Numbers less than 1 will be set to 0
 replicas: 1
 

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -167,7 +167,7 @@ env:
   ## REQUIRED: Set the user-visible Drone hostname, sans protocol.
   ## Ref: https://docs.drone.io/installation/reference/drone-server-host/
   ##
-  DRONE_SERVER_HOST: ""
+  DRONE_SERVER_HOST: drone.company.com
   ## The protocol to pair with the value in DRONE_SERVER_HOST (http or https).
   ## Ref: https://docs.drone.io/installation/reference/drone-server-proto/
   ##

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,6 +3,6 @@ remote: origin
 chart-dirs:
   - charts
 chart-repos:
-  - bitnami=https://charts.bitnami.com
-  - stable=https://kubernetes-charts.storage.googleapis.com
+  - bitnami=https://charts.bitnami.com/bitnami
+  - stable=https://charts.helm.sh/stable
 helm-extra-args: --timeout 600


### PR DESCRIPTION
Drone server is a singleton, but it may be desirable to deploy the helm chart with
 a replica count of 0. A scenario here would be deploying a cold-standby copy of
 drone to a different cluster/region/namespace/etc

In our case, we intend to keep a cold-standby deployed but spun down,
and the desire is to flip the replica count to 1 in the failover site
and flip to 0 in the production site after the drone DB has been cloned
to the failover region.

Since the service is a singleton, it's important to ensure this value
can only ever be 1 or 0. Helm templating ensures the following:

Numbers greater than or equal to 1 will be set to 1
Numbers less than 1 will be set to 0