### PR TITLE
Allow for prepending extra paths on the server ingress

### DIFF
--- a/charts/drone/templates/ingress.yaml
+++ b/charts/drone/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "drone.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- $extraPaths := .Values.ingress.extraPaths -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -31,6 +32,9 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+{{ if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
         {{- range .paths }}
           - path: {{ . }}
             backend:

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -49,6 +49,12 @@ ingress:
     - host: chart-example.local
       paths:
         - "/"
+  ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  extraPaths: []
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
When using an ALB ingress controller it is common to setup SSL redirects on the ALB using ingress annotations.  https://www.stacksimplify.com/aws-eks/aws-alb-ingress/learn-to-enable-ssl-redirect-in-alb-ingress-service-on-aws-eks/ This change allows users to prepend additional paths to enable this style of SSL redirects.