### PR TITLE
Remove required SECRET_KEY environment variable as it may be provided…

### DIFF
--- a/charts/drone-kubernetes-secrets/Chart.yaml
+++ b/charts/drone-kubernetes-secrets/Chart.yaml
@@ -4,7 +4,7 @@ name: drone-kubernetes-secrets
 description: A Kubernetes Secrets extension for Drone
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.0.0
 kubeVersion: "^1.13.0-0"
 home: https://github.com/drone/drone-kubernetes-secrets

--- a/charts/drone-kubernetes-secrets/values.schema.json
+++ b/charts/drone-kubernetes-secrets/values.schema.json
@@ -119,9 +119,6 @@
     "env": {
       "$id": "#/properties/env",
       "type": "object",
-      "required": [
-        "SECRET_KEY"
-      ],
       "properties": {
         "SECRET_KEY": {
           "$id": "#/properties/env/properties/SECRET_KEY",

--- a/charts/drone-kubernetes-secrets/values.yaml
+++ b/charts/drone-kubernetes-secrets/values.yaml
@@ -82,6 +82,8 @@ env:
   ## REQUIRED: Shared secret value for comms between the Kubernetes runner and this secrets plugin.
   ## Must match the value set in the runner's env.DRONE_SECRET_PLUGIN_TOKEN.
   ## Ref: https://kube-runner.docs.drone.io/installation/reference/drone-secret-plugin-token/
+  ## This is commented out in order to leave you the ability to set the
+  ## key via a separately provisioned secret (see existingSecretName above).
   ##
   # SECRET_KEY:
 


### PR DESCRIPTION
drone-kubernetes-secret chart update:
Removal of  **SECRET_KEY** environment variable required by default and allowing users to set key via a separately provisioned secret defined in **extraSecretNamesForEnvFrom**

Link related to discussion about the topic: 
https://discourse.drone.io/t/helm-charts-requires-secret-key-when-it-may-already-be-provided-by-extrasecretnamesforenvfrom-secret/8674