### PR TITLE
Add option to pass in topologySpreadConstraints.

### DIFF
--- a/charts/drone-runner-kube/templates/deployment.yaml
+++ b/charts/drone-runner-kube/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{ toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/drone-runner-kube/values.schema.json
+++ b/charts/drone-runner-kube/values.schema.json
@@ -5,6 +5,7 @@
   "required": [
     "image",
     "imagePullSecrets",
+    "topologySpreadConstraints",
     "replicaCount",
     "terminationGracePeriodSeconds",
     "nameOverride",
@@ -80,6 +81,10 @@
     "podAnnotations": {
       "$id": "#/properties/podAnnotations",
       "type": "object"
+    },
+    "topologySpreadConstraints": {
+      "$id": "#/properties/topologySpreadConstraints",
+      "type": "array"
     },
     "service": {
       "$id": "#/properties/service",

--- a/charts/drone-runner-kube/values.yaml
+++ b/charts/drone-runner-kube/values.yaml
@@ -38,6 +38,18 @@ securityContext: {}
 ##
 podAnnotations: {}
 
+## Using topology spread constraints, you can ensure that there is at least one runner
+## pod for each topology zone, e.g. one per arch for for multi-architecture clusters
+## or one for each region for geographically distributed cloud-hosted clusters.
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: "beta.kubernetes.io/arch"
+#   whenUnsatisfiable: "DoNotSchedule"
+#   labelSelector:
+#     matchLabels:
+#       "app.kubernetes.io/name": drone-runner-kube
+
 service:
   type: ClusterIP
   port: 3000


### PR DESCRIPTION
This allows to e.g. ensure there is at least one pod scheduled on a machine for each architecture in a multi-arch cluster (which is my specific use case). I've tested this change to ensure creation of one runner per architecture on my personal cluster using the commented example in `values.yml`.