### PR TITLE
[drone-vault-secrets] Add drone/vault secret extension to the helm charts

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -8,3 +8,5 @@ A nonexhaustive overview of the charts:
 
 * [drone](drone/README.md) - Drone server
 * [drone-runner-kube](drone-runner-kube/README.md) - The Kubernetes runner for Drone
+* [drone-kubernetes-secrets](drone-kubernetes-secrets/README.md) - The Kubernetes secrets extension for Drone
+* [drone-vault-secrets](drone-vault-secrets/README.md) - The Vault secrets extension for Drone

--- a/charts/drone-vault-secrets/.helmignore
+++ b/charts/drone-vault-secrets/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Chart dirs/files
+docs/
+ci/

--- a/charts/drone-vault-secrets/Chart.yaml
+++ b/charts/drone-vault-secrets/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+name: drone-vault-secrets
+description: A Vault Secrets extension for Drone
+# type: application
+version: 0.1.0
+appVersion: 1.0.0
+kubeVersion: "^1.13.0-0"
+home: https://github.com/drone/drone-vault
+icon: https://drone.io/apple-touch-icon.png
+keywords:
+  - continuous-delivery
+  - continuous-deployment
+  - continuous-integration
+  - docker
+  - drone
+  - drone.io
+  - go
+sources:
+  - https://github.com/drone/drone-vault
+  - https://github.com/drone/helm
+maintainers:
+  - name: Drone
+    email: hello@drone.io

--- a/charts/drone-vault-secrets/README.md
+++ b/charts/drone-vault-secrets/README.md
@@ -1,0 +1,46 @@
+# Drone Vault Secrets extension
+
+[Drone](http://drone.io/) is a Continuous Integration platform built on container technology with native vault support.
+
+This Chart is for installing the [Vault Secrets extension](https://github.com/drone/drone-vault-secrets) for Drone.
+
+## Installing Drone Vault Secrets extension
+
+See the [drone-Vault-secrets chart installation guide](./docs/install.md).
+
+## Configuring Drone Vault Secrets extension
+
+See [values.yaml](values.yaml) to see the Chart's default values.
+
+To adjust an existing Drone install's configuration:
+
+```console
+# If you have a values file:
+helm upgrade drone-vault-secrets drone/drone-vault-secrets --namespace drone --values drone-vault-secrets-values.yaml
+# If you want to change one value and don't have a values file:
+helm upgrade drone-vault-secrets drone/drone-vault-secrets --namespace drone --reuse-values --set someKey=someVal
+```
+
+## Upgrading Drone Vault Secrets extension
+
+Read the [release notes](https://discourse.drone.io/c/announcements/6) to make sure there are no backwards incompatible changes. Make adjustments to your values as needed, then run `helm upgrade`:
+
+```console
+# This pulls the latest version of the drone chart from the repo.
+help repo update
+helm upgrade drone-vault-secrets drone/drone-vault-secrets --namespace drone --values drone-vault-secrets-values.yaml
+```
+
+## Uninstalling Drone Vault Secrets extension
+
+To uninstall/delete the `drone` deployment in the `drone` namespace:
+
+```console
+helm delete drone-vault-secrets --namespace drone
+```
+
+Substitute your values if they differ from the examples. See `helm delete --help` for a full reference on `delete` parameters and flags.
+
+## Support
+
+For questions, suggestions, and discussion, visit the [Drone community site](https://discourse.drone.io/).

--- a/charts/drone-vault-secrets/ci/test-values.yaml
+++ b/charts/drone-vault-secrets/ci/test-values.yaml
@@ -1,0 +1,3 @@
+# This values file is used during CI tests.
+env:
+  DRONE_SECRET: test-secret

--- a/charts/drone-vault-secrets/docs/install.md
+++ b/charts/drone-vault-secrets/docs/install.md
@@ -1,0 +1,97 @@
+# Drone Kubernetes secrets extension installation with Helm
+
+This page will guide you through using the `drone-vault-secrets` Helm chart to install the Drone vault Secrets extension.
+
+**Note: Before beginning installation, you should have functioning deploys of Drone server and the Kubernetes runner. Refer to the their respective charts if needed:**
+
+* [drone](../../drone/README.md)
+* [drone-runner-kube](../../drone-runner-kube/README.md)
+
+## Configuration (values)
+
+**Note: This guide assumes that the Kubernetes runner and the vault secrets extension are installed in the `drone` namespace. Feel free to change this as desired, but we suggest co-locating the two in the same namespace as a start.**
+
+In order to install the chart, you'll need to pass in additional configuration. This configuration comes in the form of Helm values, which are key/value pairs. A minimal install of Drone server requires the following values:
+
+```yaml
+rbac:
+  ## The namespace that the extension is allowed to fetch secrets from. Unless
+  ## rbac.restrictToSecrets is set below, the extension will be able to pull all secrets in
+  ## the namespace specified here.
+  ##
+  secretNamespace: default
+
+## The keys within the "env" map are mounted as environment variables on the secrets extension pod.
+##
+env:
+  ## REQUIRED: Shared secret value for comms between the Kubernetes runner and this secrets plugin.
+  ## Must match the value set in the runner's env.DRONE_SECRET_PLUGIN_TOKEN.
+  ## Ref: https://kube-runner.docs.drone.io/installation/reference/drone-secret-plugin-token/
+  ##
+  DRONE_SECRET: your-shared-secret-value-here
+
+  ## The Kubernetes namespace to retrieve secrets from.
+  ##
+  KUBERNETES_NAMESPACE: default
+``` 
+
+Copy these into a new file, which we'll call `drone-vault-secrets-values.yaml`. Adjust the included defaults to reflect your environment. Make note of the value that you use for `SECRET_KEY`, as you'll need to set that in the Kubernetes runner's config.
+
+## Run the installation
+
+Run `helm install` with your values provided:
+
+```console
+$ helm install --namespace drone drone-vault-secrets drone/drone-vault-secrets -f drone-vault-secrets-values.yaml
+```
+
+To break down the above, this command means: "install the `drone/drone-vault-secrets` chart as a Helm release named `drone-vault-secrets` in the `drone` namespace. The `drone-vault-secrets.yaml` file will be used for configuring Drone." See `helm install --help` for a full list of parameters and flags.
+
+Once the `install` command is ran, your Kubernetes cluster will begin creating resources. To see how your deploy is shaping up, run:
+
+```console
+$ kubectl --namespace drone get pods
+NAME                                        READY   STATUS    RESTARTS   AGE
+drone-76d6bb8968-2s5n9                      1/1     Running   0          1h
+drone-runner-kube-696cf7b8d6-pds2h          1/1     Running   0          10m
+drone-vault-secrets-547799b4db-c58wv   1/1     Running   0          1m
+```
+
+If the `drone-vault-secrets-*` pod's state is `Running`, the secret extension process successfully launched. Check the logs to make sure there are no warnings or errors:
+
+```console
+$ kubectl --namespace drone logs \
+    -l 'app.kubernetes.io/name=drone-vault-secrets' \
+    -l 'app.kubernetes.io/component=drone-vault-secrets'
+
+time="2020-01-29T00:02:18Z" level=info msg="server listening on address :3000"
+```
+
+If you see the "starting the server" text above without error, the Drone vault secrets extension is ready.
+
+## Point Drone Kubernetes runner at Drone vault secrets
+
+Now that you have the vault secrets extension installed alongside Drone Kubernetes runner and Drone server, you'll need to update your Drone Kubernetes runner configs to point at the secrets extension. Within your values for the Kubernetes runner, add the following environment variables to the existing `env` section:
+
+```yaml
+env:
+  # <... your existing values here>
+
+  ## Ref: https://kube-runner.docs.drone.io/installation/reference/drone-secret-plugin-endpoint/
+  #
+  DRONE_SECRET_PLUGIN_ENDPOINT: http://drone-vault-secrets:3000
+  ## Ref: https://kube-runner.docs.drone.io/installation/reference/drone-secret-plugin-token/
+  #
+  DRONE_SECRET_PLUGIN_TOKEN: your-shared-secret-value-here
+```
+
+The `DRONE_SECRET_PLUGIN_ENDPOINT` variable points to a Kubernetes Services that the chart created to front the secrets extension. `DRONE_SECRET_PLUGIN_TOKEN` must be the same value that you set in the secret extension's configs as `SECRET_KEY`.
+
+
+## Next steps
+
+Now that the secrets extension and Kubernetes runner are configured, see the [Kubernetes runner secrets guide](https://docs.drone.io/configure/secrets/external/vault/) for details on how to get started creating secrets and sending builds with secrets in them.
+
+## Help!
+
+If you have questions or have encountered issues, visit the [Drone community site](https://discourse.drone.io/) to share.

--- a/charts/drone-vault-secrets/templates/_helpers.tpl
+++ b/charts/drone-vault-secrets/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "drone-vault-secrets.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "drone-vault-secrets.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "drone-vault-secrets.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "drone-vault-secrets.labels" -}}
+helm.sh/chart: {{ include "drone-vault-secrets.chart" . }}
+{{ include "drone-vault-secrets.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "drone-vault-secrets.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "drone-vault-secrets.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: drone-vault-secrets
+{{- end -}}

--- a/charts/drone-vault-secrets/templates/configmap.yaml
+++ b/charts/drone-vault-secrets/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "drone-vault-secrets.fullname" . }}
+  labels:
+    {{- include "drone-vault-secrets.labels" . | nindent 4 }}
+data:
+  {{/*
+    Rather than maintain a comprehensive ConfigMap, we map all sub-keys of the "env" value here.
+    This allows for more flexibility and less Chart churn as Drone evolves.
+  */}}
+{{- range $envKey, $envVal := .Values.env }}
+  {{ $envKey | upper }}: {{ $envVal | quote }}
+{{- end }}

--- a/charts/drone-vault-secrets/templates/deployment.yaml
+++ b/charts/drone-vault-secrets/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "drone-vault-secrets.fullname" . }}
+  labels:
+    {{- include "drone-vault-secrets.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "drone-vault-secrets.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "drone-vault-secrets.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.podAnnotations }}
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "drone-vault-secrets.fullname" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: server
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "drone-vault-secrets.fullname" . }}
+          {{- range .Values.extraSecretNamesForEnvFrom }}
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/drone-vault-secrets/templates/rbac.yaml
+++ b/charts/drone-vault-secrets/templates/rbac.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "drone-vault-secrets.fullname" . }}
+  labels:
+    {{- include "drone-vault-secrets.labels" . | nindent 4 }}
+
+{{/* A Role is created for the namespace specified in rbac.secretNamespace. */}}
+---
+{{ if .Values.rbac.enabled -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "drone-vault-secrets.fullname" . }}
+  namespace: {{ .Values.rbac.secretNamespace | quote }}
+  labels:
+    {{- include "drone-vault-secrets.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+  {{ if .Values.rbac.restrictToSecrets }}
+    resourceNames:
+    {{- toYaml .Values.rbac.restrictToSecrets | nindent 6 }}
+  {{ end }}
+    verbs:
+    - get
+    - watch
+{{ end -}}
+
+{{/* The role gets bound to the runner's ServiceAccount in the secret namespace. */}}
+---
+{{ if .Values.rbac.enabled -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "drone-vault-secrets.fullname" . }}
+  namespace: {{ .Values.rbac.secretNamespace | quote }}
+  labels:
+    {{- include "drone-vault-secrets.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "drone-vault-secrets.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "drone-vault-secrets.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end -}}

--- a/charts/drone-vault-secrets/templates/service.yaml
+++ b/charts/drone-vault-secrets/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "drone-vault-secrets.fullname" . }}
+  labels:
+    {{- include "drone-vault-secrets.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "drone-vault-secrets.selectorLabels" . | nindent 4 }}

--- a/charts/drone-vault-secrets/values.schema.json
+++ b/charts/drone-vault-secrets/values.schema.json
@@ -1,0 +1,131 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "image",
+    "imagePullSecrets",
+    "replicaCount",
+    "nameOverride",
+    "fullnameOverride",
+    "podSecurityContext",
+    "securityContext",
+    "podAnnotations",
+    "service",
+    "resources",
+    "nodeSelector",
+    "tolerations",
+    "affinity",
+    "extraSecretNamesForEnvFrom",
+    "env"
+  ],
+  "properties": {
+    "image": {
+      "$id": "#/properties/image",
+      "type": "object",
+      "required": [
+        "repository",
+        "tag",
+        "pullPolicy"
+      ],
+      "properties": {
+        "repository": {
+          "$id": "#/properties/image/properties/repository",
+          "type": "string"
+        },
+        "tag": {
+          "$id": "#/properties/image/properties/tag",
+          "type": "string"
+        },
+        "pullPolicy": {
+          "$id": "#/properties/image/properties/pullPolicy",
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "$id": "#/properties/imagePullSecrets",
+      "type": "array"
+    },
+    "replicaCount": {
+      "$id": "#/properties/replicaCount",
+      "type": "integer",
+      "minimum": 0
+    },
+    "nameOverride": {
+      "$id": "#/properties/nameOverride",
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "$id": "#/properties/fullnameOverride",
+      "type": "string"
+    },
+    "podSecurityContext": {
+      "$id": "#/properties/podSecurityContext",
+      "type": "object"
+    },
+    "securityContext": {
+      "$id": "#/properties/securityContext",
+      "type": "object"
+    },
+    "podAnnotations": {
+      "$id": "#/properties/podAnnotations",
+      "type": "object"
+    },
+    "service": {
+      "$id": "#/properties/service",
+      "type": "object",
+      "required": [
+        "type",
+        "port"
+      ],
+      "properties": {
+        "type": {
+          "$id": "#/properties/service/properties/type",
+          "type": "string",
+          "enum": ["ClusterIP", "ExternalName", "LoadBalancer", "NodePort"]
+        },
+        "port": {
+          "$id": "#/properties/service/properties/port",
+          "type": "integer"
+        }
+      }
+    },
+    "resources": {
+      "$id": "#/properties/resources",
+      "type": "object"
+    },
+    "nodeSelector": {
+      "$id": "#/properties/nodeSelector",
+      "type": "object"
+    },
+    "tolerations": {
+      "$id": "#/properties/tolerations",
+      "type": "array"
+    },
+    "affinity": {
+      "$id": "#/properties/affinity",
+      "type": "object"
+    },
+    "rbac": {
+      "$id": "#/properties/rbac",
+      "type": "object"
+    },
+    "extraSecretNamesForEnvFrom": {
+      "$id": "#/properties/extraSecretNamesForEnvFrom",
+      "type": "array"
+    },
+    "env": {
+      "$id": "#/properties/env",
+      "type": "object",
+      "properties": {
+        "SECRET_KEY": {
+          "$id": "#/properties/env/properties/SECRET_KEY",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/charts/drone-vault-secrets/values.yaml
+++ b/charts/drone-vault-secrets/values.yaml
@@ -59,6 +59,21 @@ tolerations: []
 
 affinity: {}
 
+rbac:
+  ## If true, create a Role + Rolebinding in the secretNamespace that allows the extension to
+  ## fetch Kubernetes Secrets.
+  ##
+  enabled: true
+  ## The namespace that the extension is allowed to fetch secrets from. Unless
+  ## rbac.restrictToSecrets is set below, the extension will be able to pull all secrets in
+  ## the namespace specified here.
+  ##
+  secretNamespace: default
+  ## Optionally restrict secret pulls to a subset of secrets in the secret namespace. This is
+  ## particularly useful if your secrets extension is fetching secrets from a namespace that other
+  ## Drone components have been deployed to.
+  restrictToSecrets: []
+
 ## If you'd like to provide your own Kubernetes Secret object instead of passing your values
 ## in un-encrypted, pass in the name of a created + populated Secret in the same Namespace
 ## as the pod. All secrets within this configmap will be mounted as environment variables,

--- a/charts/drone-vault-secrets/values.yaml
+++ b/charts/drone-vault-secrets/values.yaml
@@ -1,0 +1,89 @@
+image:
+  repository: drone/vault
+  tag: latest
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+
+## If you need to pull images from a private Docker image repository, pass in the name
+## of a Kubernetes Secret that contains the needed secret. For more details, see:
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+imagePullSecrets: []
+# - name: "image-pull-secret"
+
+## For small or experimental deployments of the Kubernetes runner, 1 replica will suffice.
+## For production cases, 2-3 are recommended. This does not grant additional parallelism,
+## but does ensure that upgrades, config changes, and disruptions are handled more gracefully.
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 3000
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+## If you'd like to provide your own Kubernetes Secret object instead of passing your values
+## in un-encrypted, pass in the name of a created + populated Secret in the same Namespace
+## as the pod. All secrets within this configmap will be mounted as environment variables,
+## with each key/value mapping to a corresponding environment variable on the pod.
+##
+extraSecretNamesForEnvFrom: []
+# - my-drone-secrets
+
+## The keys within the "env" map are mounted as environment variables on the secrets extension pod.
+##
+env:
+  ## REQUIRED: Shared secret value for comms between the Kubernetes runner and this secrets plugin.
+  ## Must match the value set in the runner's env.DRONE_SECRET_PLUGIN_TOKEN.
+  ## Ref: https://kube-runner.docs.drone.io/installation/reference/drone-secret-plugin-token/
+  ## This is commented out in order to leave you the ability to set the
+  ## key via a separately provisioned secret (see existingSecretName above).
+  ##
+  # DRONE_SECRET:
+  ##
+  ## 
+  ## Vault related parameter
+  ## For more information about Vault extension parameter, you can take a look here:
+  ## https://github.com/drone/drone-vault
+
+  ## The Kubernetes namespace to retrieve secrets from.
+  ##
+  KUBERNETES_NAMESPACE: default
+

--- a/charts/drone-vault-secrets/values.yaml
+++ b/charts/drone-vault-secrets/values.yaml
@@ -78,7 +78,7 @@ env:
   ##
   # DRONE_SECRET:
   ##
-  ## 
+  ##
   ## Vault related parameter
   ## For more information about Vault extension parameter, you can take a look here:
   ## https://github.com/drone/drone-vault
@@ -86,4 +86,3 @@ env:
   ## The Kubernetes namespace to retrieve secrets from.
   ##
   KUBERNETES_NAMESPACE: default
-


### PR DESCRIPTION
This PR provide a helm charts for the vault secret extension.
Most of the helm charts take for model the drone-kubernetes-secret, and was tested on EKS 1.18 with a approle authentication.