### PR TITLE
Allow command to be overwritten

### DIFF
--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.customCommand }}
+          command: {{ toYaml . | nindent 12 }}
+        {{- end }}
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
This will allow server container command to be overwritten through customCommand value for injecting wrapper scripts.
For example:

```
customCommand: ["/bin/sh", "-c", "apk add curl jq && . /scripts/drone-gitea-setup.sh && /bin/drone-server"]

extraVolumes:
  - name: wrapper
    configMap:
      name: drone-gitea-setup-wrapper
      defaultMode: 0744

extraVolumeMounts:
  - name: wrapper
    mountPath: /scripts
```

This can for example inject some environment variables exported from the script and allow fully automated integrations from e.g. gitea (by generating oauth2 creds from the rest api)

Idea from article:
https://etoews.github.io/blog/2017/07/29/inject-an-executable-script-into-a-container-in-kubernetes/