### PR TITLE
Be a TLS enabled LoadBalancer

### DIFF
--- a/charts/drone/templates/_helpers.tpl
+++ b/charts/drone/templates/_helpers.tpl
@@ -62,3 +62,16 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+TLS enabled via extraVolumes
+*/}}
+{{- define "drone.tlsEnabled" -}}
+  {{/* Iterate through each of the extraVolumes */}}
+  {{- range .Values.extraVolumes -}}
+    {{/* If a volume called certs exist TLS is enabled */}}
+    {{- if eq .name "certs" }}
+true
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -42,7 +42,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /
+          {{- if (include "drone.tlsEnabled" .) }}
+              port: 443
+              scheme: HTTPS
+          {{- else }}
               port: http
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/charts/drone/templates/service.yaml
+++ b/charts/drone/templates/service.yaml
@@ -6,10 +6,21 @@ metadata:
     {{- include "drone.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+{{- if eq "LoadBalancer" .Values.service.type }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  ports:
+  {{- range $key, $val := .Values.servicePorts }}
+    - port: {{ $val.port }}
+      targetPort: {{ $val.targetPort }}
+      protocol: {{ $val.protocol }}
+      name: {{ $key }}
+  {{- end }}
+{{- else }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+{{- end }}
   selector:
     {{- include "drone.selectorLabels" . | nindent 4 }}

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -40,6 +40,17 @@ service:
   type: ClusterIP
   port: 80
 
+## For a LoadBalancer service define the ports to use
+servicePorts: {}
+#  http:
+#    port: 80
+#    targetPort: 80
+#    protocol: TCP
+#  https:
+#    port: 443
+#    targetPort: 443
+#    protocol: TCP
+
 ingress:
   enabled: false
   annotations: {}
@@ -159,7 +170,7 @@ env:
   ## REQUIRED: Set the user-visible Drone hostname, sans protocol.
   ## Ref: https://docs.drone.io/installation/reference/drone-server-host/
   ##
-  DRONE_SERVER_HOST: ""
+  DRONE_SERVER_HOST: "chart-example.local"
   ## The protocol to pair with the value in DRONE_SERVER_HOST (http or https).
   ## Ref: https://docs.drone.io/installation/reference/drone-server-proto/
   ##


### PR DESCRIPTION
We're using drone as a LoadBalancer service with TLS enabled via the certs extraVolume.
There are two problems with this.

1. There is only one `ports` to be open via the service, and is hardcoded to be HTTP. The `servicePorts {}` map makes `ports` totally configurable.
2. The liveness probe is hardcoded to talk HTTP to the port HTTP, but with TLS enabled drone responds with a HTTP 307 to plan HTTP requests, causing the liveness probe to fail. I'm using the existence of a `certs` volume to decide if TLS is enabled, and if so do HTTPS liveness probes.