### PR TITLE
Allow control over containerPort

### DIFF
--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,7 +4,7 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: 1.9.0
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/

--- a/charts/drone/templates/configmap.yaml
+++ b/charts/drone/templates/configmap.yaml
@@ -9,6 +9,8 @@ data:
     Rather than maintain a comprehensive ConfigMap, we map all sub-keys of the "env" value here.
     This allows for more flexibility and less Chart churn as Drone evolves.
   */}}
-{{- range $envKey, $envVal := .Values.env }}
+{{- $defaultEnvs := dict "DRONE_SERVER_PORT" (cat ":" .Values.containerPort) }}
+{{- $mergedValues := merge .Values.env $defaultEnvs }}
+{{- range $envKey, $envVal := $mergedValues }}
   {{ $envKey | upper }}: {{ $envVal | quote }}
 {{- end }}

--- a/charts/drone/templates/configmap.yaml
+++ b/charts/drone/templates/configmap.yaml
@@ -9,7 +9,8 @@ data:
     Rather than maintain a comprehensive ConfigMap, we map all sub-keys of the "env" value here.
     This allows for more flexibility and less Chart churn as Drone evolves.
   */}}
-{{- $defaultEnvs := dict "DRONE_SERVER_PORT" (cat ":" .Values.containerPort) }}
+{{- $droneServerPort := printf ":%v" .Values.containerPort }}
+{{- $defaultEnvs := dict "DRONE_SERVER_PORT" $droneServerPort }}
 {{- $mergedValues := merge .Values.env $defaultEnvs }}
 {{- range $envKey, $envVal := $mergedValues }}
   {{ $envKey | upper }}: {{ $envVal | quote }}

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: http
+              port: {{ .Values.containerPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/charts/drone/templates/service.yaml
+++ b/charts/drone/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.containerPort }}
       protocol: TCP
       name: http
   selector:

--- a/charts/drone/values.schema.json
+++ b/charts/drone/values.schema.json
@@ -12,6 +12,7 @@
     "podAnnotations",
     "service",
     "ingress",
+    "containerPort",
     "resources",
     "nodeSelector",
     "tolerations",
@@ -69,6 +70,10 @@
     "podAnnotations": {
       "$id": "#/properties/podAnnotations",
       "type": "object"
+    },
+    "containerPort": {
+      "$id": "#/properties/containerPort",
+      "type": "integer"
     },
     "service": {
       "$id": "#/properties/service",

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -13,6 +13,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Change containerPort to some custom value
+containerPort: 8080
+
 # Drone server does not interact with the Kubernetes API server
 automountServiceAccountToken: false
 


### PR DESCRIPTION
Allow control over containerPort. Set default value to 8080.

Motivation - by default port is always set to 80. I wanted to control it and change to different value in order to start the container without root.