### PR TITLE
feat: Bump App version to 2.7.3

### DIFF
--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,8 +4,8 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.1.7
-appVersion: 1.9.0
+version: 0.1.8
+appVersion: 2.7.3
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png


### PR DESCRIPTION
Drone version is upgraded many times, however this helm chart still points on an old version.

REF: https://hub.docker.com/layers/drone/drone/2.7.3/images/sha256-4e964e6cdd3347295fed0ea330c9a89d45830086c0f143b607f4e2a10b95cffd?context=explore