### PR TITLE
drone-runner-kube Updates drone-runner-kube service account to suppor…

### DIFF
--- a/charts/drone-runner-kube/Chart.yaml
+++ b/charts/drone-runner-kube/Chart.yaml
@@ -4,7 +4,7 @@ name: drone-runner-kube
 description: The Drone Kubernetes runner launches builds in Kubernetes Jobs
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 1.0.0
 kubeVersion: "^1.13.0-0"
 home: https://kube-runner.docs.drone.io/

--- a/charts/drone-runner-kube/templates/rbac.yaml
+++ b/charts/drone-runner-kube/templates/rbac.yaml
@@ -1,6 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
   name: {{ include "drone-runner-kube.fullname" . }}
   labels:
     {{- include "drone-runner-kube.labels" . | nindent 4 }}

--- a/charts/drone-runner-kube/values.schema.json
+++ b/charts/drone-runner-kube/values.schema.json
@@ -148,6 +148,10 @@
       "$id": "#/properties/rbac",
       "type": "object"
     },
+    "serviceAccount": {
+      "$id": "#/properties/serviceAccount",
+      "type": "object"
+    },
     "extraVolumes": {
       "$id": "#/properties/extraVolumes",
       "type": "array"

--- a/charts/drone-runner-kube/values.yaml
+++ b/charts/drone-runner-kube/values.yaml
@@ -100,6 +100,10 @@ rbac:
   buildNamespaces:
     - default
 
+## If you require annotations on the drone-runner-kube service account declare them here.
+serviceAccount:
+  annotations: {}
+
 ## The keys within the "env" map are mounted as environment variables on the Kubernetes runner pod.
 ## See the full reference of Kubernetes runner environment variables here:
 ## Ref: https://kube-runner.docs.drone.io/installation/reference/


### PR DESCRIPTION
…t annotations

We require annotations on our drone-runner-kube service account in EKS in order to bind the service account to an IAM role for access to resources outside out Kubernetes cluster. 

This change allows developers to add annotations to the drone-runner-kube service account, or leave it blank by default. 