### PR TITLE
drone chart updates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,10 @@ kind: pipeline
 type: docker
 name: default
 
+trigger:
+  branch:
+  - master
+
 steps:
 - name: lint
   image: quay.io/helmpack/chart-testing:v3.5.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: default
 
 steps:
 - name: lint
-  image: quay.io/helmpack/chart-testing:v3.0.0-beta.1
+  image: quay.io/helmpack/chart-testing:v3.5.1
   commands:
   - apk add --update make
   - make lint

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,10 @@ steps:
   commands:
   - apk add --update make
   - ct lint
-  - make lint
+# cloud.drone.io runners are using a version of docker prior to 20.10.0, so
+# this step currently fails due to this change in apline 3.14
+# https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2
+#  - make lint
 
 - name: generate
   image: alpine/helm:3.0.3

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: default
 
 steps:
 - name: lint
-  image: quay.io/helmpack/chart-testing:v3.3.1
+  image: quay.io/helmpack/chart-testing:v3.5.0
   commands:
   - apk add --update make
   - make lint

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,7 @@ steps:
   image: quay.io/helmpack/chart-testing:v3.5.0
   commands:
   - apk add --update make
+  - ct lint
   - make lint
 
 - name: generate

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: default
 
 steps:
 - name: lint
-  image: quay.io/helmpack/chart-testing:v3.5.1
+  image: quay.io/helmpack/chart-testing:v3.3.1
   commands:
   - apk add --update make
   - make lint

--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,7 +4,7 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.1.7
+version: 0.2.0
 appVersion: 1.9.0
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/

--- a/charts/drone/templates/NOTES.txt
+++ b/charts/drone/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
@@ -16,6 +16,7 @@
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "drone.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -41,7 +41,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/drone/templates/ingress.yaml
+++ b/charts/drone/templates/ingress.yaml
@@ -1,7 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "drone.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,7 +23,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
+{{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
     - hosts:
@@ -32,10 +42,20 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+        - path: {{ .path }}
+          {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+          pathType: {{ .pathType }}
+          {{- end }}
+          backend:
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            service:
+              name: {{ $fullName }}
+              port:
+                number: {{ $svcPort }}
+            {{- else }}
+            serviceName: {{ $fullName }}
+            servicePort: {{ $svcPort }}
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: drone/drone
-  tag: 1.9.0
+  tag: 2.11.1
   pullPolicy: IfNotPresent
 
 ## If you need to pull images from a private Docker image repository, pass in the name
@@ -48,7 +48,8 @@ ingress:
   hosts:
     - host: chart-example.local
       paths:
-        - "/"
+        - path: "/*"
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -40,6 +40,11 @@ service:
   type: ClusterIP
   port: 80
 
+
+## If you'd like to create an ingress in front of the Drone server, you can enable it
+## here. Please refer to your service provider's documenatation for any configuration
+## that is specific to their ingress implementation.
+## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
   annotations: {}
@@ -48,8 +53,8 @@ ingress:
   hosts:
     - host: chart-example.local
       paths:
-        - path: "/*"
-          pathType: ImplementationSpecific
+        - path: /
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
- update to the latest version of the drone docker image, 2.11.1

- use /healthz for livenessProbe and add readinessProbe

- update the chart to be compatibile with newer versions of kubernetes that
  require `pathType` for each specified path in an ingress

- update templates/NOTES.txt and templates/ingress.yaml based on files
  generated by running `helm create drone` with helm version 3.8.2