### PR TITLE
Drone release label

### DIFF
--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,7 +4,7 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 2.11.1
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/

--- a/charts/drone/templates/_helpers.tpl
+++ b/charts/drone/templates/_helpers.tpl
@@ -35,6 +35,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "drone.labels" -}}
+{{- if .Release.Name -}}
+release: {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 helm.sh/chart: {{ include "drone.chart" . }}
 {{ include "drone.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/drone/templates/_helpers.tpl
+++ b/charts/drone/templates/_helpers.tpl
@@ -35,9 +35,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "drone.labels" -}}
-{{- if .Release.Name -}}
+{{- if .Release.Name }}
 release: {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- end }}
 helm.sh/chart: {{ include "drone.chart" . }}
 {{ include "drone.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/drone/templates/_helpers.tpl
+++ b/charts/drone/templates/_helpers.tpl
@@ -35,8 +35,8 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "drone.labels" -}}
-{{- if .Release.Name }}
-release: {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- if .Release.Name -}}
+release: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 helm.sh/chart: {{ include "drone.chart" . }}
 {{ include "drone.selectorLabels" . }}


### PR DESCRIPTION
this sets the common `release` label to `Release.Name` which is a Harness CD requirement https://ngdocs.harness.io/article/lbhf2h71at-native-helm-quickstart