### PR TITLE
service account support for drone server

### DIFF
--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,7 +4,7 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.2.5
+version: 0.3.0
 appVersion: 2.12.0
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      serviceAccountName: {{ include "drone.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/drone/templates/serviceaccount.yaml
+++ b/charts/drone/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "drone.serviceAccountName" . }}
+  labels:
+    {{- include "drone.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/drone/values.schema.json
+++ b/charts/drone/values.schema.json
@@ -42,11 +42,7 @@
         "pullPolicy": {
           "$id": "#/properties/image/properties/pullPolicy",
           "type": "string",
-          "enum": [
-            "Always",
-            "IfNotPresent",
-            "Never"
-          ]
+          "enum": ["Always", "IfNotPresent", "Never"]
         }
       }
     },
@@ -89,12 +85,7 @@
         "type": {
           "$id": "#/properties/service/properties/type",
           "type": "string",
-          "enum": [
-            "ClusterIP",
-            "ExternalName",
-            "LoadBalancer",
-            "NodePort"
-          ]
+          "enum": ["ClusterIP", "ExternalName", "LoadBalancer", "NodePort"]
         },
         "port": {
           "$id": "#/properties/service/properties/port",
@@ -134,12 +125,12 @@
       "$id": "#/properties/resources",
       "type": "object"
     },
-    "serviceAccount": {
-      "$id": "#/properties/serviceAccount",
-      "type": "object"
-    },
     "nodeSelector": {
       "$id": "#/properties/nodeSelector",
+      "type": "object"
+    },
+    "serviceAccount": {
+      "$id": "#/properties/serviceAccount",
       "type": "object"
     },
     "tolerations": {

--- a/charts/drone/values.schema.json
+++ b/charts/drone/values.schema.json
@@ -42,7 +42,11 @@
         "pullPolicy": {
           "$id": "#/properties/image/properties/pullPolicy",
           "type": "string",
-          "enum": ["Always", "IfNotPresent", "Never"]
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
         }
       }
     },
@@ -85,7 +89,12 @@
         "type": {
           "$id": "#/properties/service/properties/type",
           "type": "string",
-          "enum": ["ClusterIP", "ExternalName", "LoadBalancer", "NodePort"]
+          "enum": [
+            "ClusterIP",
+            "ExternalName",
+            "LoadBalancer",
+            "NodePort"
+          ]
         },
         "port": {
           "$id": "#/properties/service/properties/port",
@@ -123,6 +132,10 @@
     },
     "resources": {
       "$id": "#/properties/resources",
+      "type": "object"
+    },
+    "serviceAccount": {
+      "$id": "#/properties/serviceAccount",
       "type": "object"
     },
     "nodeSelector": {

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -13,13 +13,24 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 # Drone server does not interact with the Kubernetes API server
 automountServiceAccountToken: false
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -40,14 +51,14 @@ service:
   type: ClusterIP
   port: 80
 
-
 ## If you'd like to create an ingress in front of the Drone server, you can enable it
 ## here. Please refer to your service provider's documenatation for any configuration
 ## that is specific to their ingress implementation.
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -60,7 +71,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -25,12 +25,10 @@ serviceAccount:
 # Drone server does not interact with the Kubernetes API server
 automountServiceAccountToken: false
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -57,8 +55,7 @@ service:
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -71,8 +68,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  {}
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi


### PR DESCRIPTION
Alternative fix for #31 

Allows service accounts to be created/managed by helm for drone in the usual fashion. Code copied directly from `helm create` with the exception of the required `drone.serviceAccountName` helper which was already defined.

Schema update copied from `drone-runner-docker`.

Left `automountServiceAccountToken` as is (https://github.com/drone/charts/pull/76/files#diff-085c19ead4ddab83dba353448d341f2781cbb60599e04b9a36da2a50b2f681e7R29)