### PR TITLE
fix: configure nodePort when defined

### DIFF
--- a/charts/drone/templates/service.yaml
+++ b/charts/drone/templates/service.yaml
@@ -15,6 +15,9 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       name: http
   selector:
     {{- include "drone.selectorLabels" . | nindent 4 }}

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -47,8 +47,9 @@ updateStrategy: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
   annotations: {}
+  nodePort:
 
 ## If you'd like to create an ingress in front of the Drone server, you can enable it
 ## here. Please refer to your service provider's documenatation for any configuration


### PR DESCRIPTION
Allows the chart to configure the nodePort value if defined.

@jimsheldon  - can please review and merge