### PR TITLE
drone-runner-kube: fix ingress path

### DIFF
--- a/charts/drone-runner-kube/Chart.yaml
+++ b/charts/drone-runner-kube/Chart.yaml
@@ -4,7 +4,7 @@ name: drone-runner-kube
 description: The Drone Kubernetes runner launches builds in Kubernetes Jobs
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: 1.0.0
 kubeVersion: "^1.13.0-0"
 home: https://kube-runner.docs.drone.io/

--- a/charts/drone-runner-kube/templates/ingress.yaml
+++ b/charts/drone-runner-kube/templates/ingress.yaml
@@ -42,7 +42,7 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}

--- a/charts/drone-runner-kube/values.yaml
+++ b/charts/drone-runner-kube/values.yaml
@@ -50,7 +50,8 @@ ingress:
   hosts:
     - host: chart-example.local
       paths:
-        - "/"
+        - path: /
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
[this commit](https://github.com/drone/charts/commit/5b9cee8f984c5c5a37ed2652038a9ba65146d568) correctly added support for configuring `pathType` in ingress resources, but did not update the ingress spec to configure `path` correctly, and did not update the values.yaml to reflect the correct way to configure ingress. 

Without these fixes, it's impossible to apply the drone-runner-kube helm chart version 0.1.9 with `ingress.enabled` set to true. either the server will reject the ingress resource because it's missing pathType, or the ingress path will be configured with `path: map[path:/ pathType:Prefix]` which is invalid.

These changes make the ingress resource in drone-runner-kube look almost identical to the ingress resource in the drone helm chart.

Resolves https://github.com/drone/charts/issues/87