### PR TITLE
fix: ability to add hostAliases to drone server pods

### DIFF
--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,7 +4,7 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: 2.12.1
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -76,6 +76,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
       volumes:
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8}}

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -1,3 +1,10 @@
+# -- Mapping between IP and hostnames that will be injected as entries in the pod's hosts files
+# https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+hostAliases: []
+  # - ip: 10.20.30.40
+  #   hostnames:
+  #   - gitea-127.0.0.1.sslip.io
+
 image:
   repository: drone/drone
   tag: 2.12.1


### PR DESCRIPTION
Adds the ability to add `hostAliases`[1] to the Drone server deployments

[1]: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/


@jimsheldon  can you please review and merge?