### PR TITLE
addind drone-gc to drone-runner-docker chart

### DIFF
--- a/charts/drone-runner-docker/Chart.yaml
+++ b/charts/drone-runner-docker/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for the Drone Docker runner which uses Docker-in-Docke
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
 version: 0.3.1
-appVersion: "1.8.1"
+appVersion: "1.9.0"
 kubeVersion: "^1.13.0-0"
 home: https://docs.drone.io/runner/docker/overview/
 icon: https://drone.io/apple-touch-icon.png

--- a/charts/drone-runner-docker/Chart.yaml
+++ b/charts/drone-runner-docker/Chart.yaml
@@ -4,8 +4,8 @@ name: drone-runner-docker
 description: A Helm chart for the Drone Docker runner which uses Docker-in-Docker (dind)
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.3.1
-appVersion: "1.9.0"
+version: 0.4.0
+appVersion: "1.8.1"
 kubeVersion: "^1.13.0-0"
 home: https://docs.drone.io/runner/docker/overview/
 icon: https://drone.io/apple-touch-icon.png

--- a/charts/drone-runner-docker/README.md
+++ b/charts/drone-runner-docker/README.md
@@ -1,6 +1,6 @@
 # Drone Docker runner
 
-[Drone](http://drone.io/) is a Continuous Integration platform built on container technology with native Kubernetes support.
+[Drone](http://drone.io/) is a Continuous Integration platform built on container technology.
 
 This Chart is for installing the [Docker runner](https://docs.drone.io/runner/docker/) for Drone.
 
@@ -11,6 +11,8 @@ See the [drone-runner-docker chart installation guide](./docs/install.md).
 ## Configuring Drone Docker runner
 
 See [values.yaml](values.yaml) to see the Chart's default values. Refer to the [Docker runner reference](https://docs.drone.io/runner/docker/configuration/reference/) for a more complete list of options.
+
+:information_source: In addition to the Drone Docker runner container, this chart runs [Docker-in-Docker](https://hub.docker.com/_/docker) (to run Docker containers in pipelines) and [Drone GC](https://github.com/drone/drone-gc) (for automatically pruning Docker images) containers within the pod. 
 
 To adjust an existing Drone install's configuration:
 

--- a/charts/drone-runner-docker/templates/deployment.yaml
+++ b/charts/drone-runner-docker/templates/deployment.yaml
@@ -75,6 +75,24 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if $.Values.gc.enabled }}
+        - name: gc
+          image: "{{ .Values.gc.repository }}:{{ .Values.gc.tag }}"
+          imagePullPolicy: {{ .Values.gc.pullPolicy }}
+          {{- with .Values.gc.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: DOCKER_HOST
+              value: {{ .Values.env.DOCKER_HOST }}
+          {{- if $.Values.gc.env }}
+            {{- range $key, $value := $.Values.gc.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/drone-runner-docker/values.yaml
+++ b/charts/drone-runner-docker/values.yaml
@@ -54,6 +54,26 @@ dind:
       mountPath: /var/lib/docker
       subPath: docker
 
+## Values used only for the Drone Garbage Collector container
+gc:
+  enabled: true
+  ## The official Drone Garbage collector image, change tag to use a different version.
+  ## ref: https://hub.docker.com/r/drone/gc/tags
+  ##
+  repository: drone/gc
+  tag: 1.0.0
+  pullPolicy: IfNotPresent
+  securityContext:
+    {}
+  env:
+    GC_DEBUG: false
+    GC_DEBUG_COLOR: "false"
+    GC_DEBUG_PRETTY: "false"
+    GC_IGNORE_IMAGES: ""
+    GC_IGNORE_CONTAINERS: ""
+    GC_INTERVAL: "5m"
+    GC_CACHE: "5gb"
+
 imagePullSecrets: []
 
 ## When the runner receives a SIGTERM/SIGINT (config update, upgrade, etc), it will wait until


### PR DESCRIPTION
drone-gc will automatically prune docker images used in pipeline steps, this will keep the pod from using too much disk space