### PR TITLE
Deployment resources fix.

### DIFF
--- a/charts/drone-runner-docker/Chart.yaml
+++ b/charts/drone-runner-docker/Chart.yaml
@@ -4,7 +4,7 @@ name: drone-runner-docker
 description: A Helm chart for the Drone Docker runner which uses Docker-in-Docker (dind)
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.8.1"
 kubeVersion: "^1.13.0-0"
 home: https://docs.drone.io/runner/docker/overview/

--- a/charts/drone-runner-docker/templates/deployment.yaml
+++ b/charts/drone-runner-docker/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
               port: tcp
           {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Seems to have broken by https://github.com/drone/charts/pull/94/files#diff-f55f7583e71bb04f7e96f5949a964a9f7ca22817547e6cddbeeaa90b0a778e34R74 the `with` keyword changes the context of `.`.