### PR TITLE
Fix autoscaling

### DIFF
--- a/charts/drone-runner-docker/Chart.yaml
+++ b/charts/drone-runner-docker/Chart.yaml
@@ -4,7 +4,7 @@ name: drone-runner-docker
 description: A Helm chart for the Drone Docker runner which uses Docker-in-Docker (dind)
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.4.3
+version: 0.5.0
 appVersion: "1.8.1"
 kubeVersion: "^1.13.0-0"
 home: https://docs.drone.io/runner/docker/overview/

--- a/charts/drone-runner-docker/templates/hpa.yaml
+++ b/charts/drone-runner-docker/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "drone-runner-docker.fullname" . }}
@@ -17,12 +21,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+          type: Utilization
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+          type: Utilization
     {{- end }}
 {{- end }}


### PR DESCRIPTION
I ran into problems activating HPA with the current version of the helm chart. Based on [this](https://community.harness.io/t/drone-runner-docker-cannot-enable-autoscaling-in-1-25/12880) comment I created a PR. I tested deployment with `apiVersion: autoscaling/v2` and `apiVersion: autoscaling/v2beta2` on a 1.25 Kubernetes cluster. With  `apiVersion: autoscaling/v2beta2` I got a couple of deprecation notices:
```
autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+
```
Only tested `autoscaling/v2beta2` because I had to change `targetAverageUtilization`, see line 20 and 26.

BR,
panda