### PR TITLE
fix: use changed scope to fix error parsing securityContexts

### DIFF
--- a/charts/drone-runner-docker/Chart.yaml
+++ b/charts/drone-runner-docker/Chart.yaml
@@ -4,7 +4,7 @@ name: drone-runner-docker
 description: A Helm chart for the Drone Docker runner which uses Docker-in-Docker (dind)
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "1.8.1"
 kubeVersion: "^1.13.0-0"
 home: https://docs.drone.io/runner/docker/overview/

--- a/charts/drone-runner-docker/templates/deployment.yaml
+++ b/charts/drone-runner-docker/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: {{ include "drone-runner-docker.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
@@ -104,7 +104,7 @@ spec:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
Using the `with` keyword in your helm chart changes the Scope. Thus the .Values reference within the scoped block needs to be changed to just `.`.