### PR TITLE
Fix drone-runner-docker deployment port name

### DIFF
--- a/charts/drone-runner-docker/templates/deployment.yaml
+++ b/charts/drone-runner-docker/templates/deployment.yaml
@@ -127,15 +127,15 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           ports:
-            - name: tcp
+            - name: http
               containerPort: 3000
               protocol: TCP
           livenessProbe:
             tcpSocket:
-              port: tcp
+              port: http
           readinessProbe:
             tcpSocket:
-              port: tcp
+              port: http
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Endpoints aren't properly assigned when the port name in the deployment doesn't match the port name in the service ([more context](https://github.com/kubernetes/kubernetes/issues/47711#issuecomment-524585328)). The port names for the server chart match but not for the docker runner, so this updates the docker runner deployment to use the same name as the service.