### PR TITLE
Add missing terminationGracePeriodSeconds value to deployment template

### DIFF
--- a/charts/drone-runner-docker/Chart.yaml
+++ b/charts/drone-runner-docker/Chart.yaml
@@ -4,7 +4,7 @@ name: drone-runner-docker
 description: A Helm chart for the Drone Docker runner which uses Docker-in-Docker (dind)
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: "1.8.1"
 kubeVersion: "^1.13.0-0"
 home: https://docs.drone.io/runner/docker/overview/

--- a/charts/drone-runner-docker/templates/deployment.yaml
+++ b/charts/drone-runner-docker/templates/deployment.yaml
@@ -152,3 +152,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}


### PR DESCRIPTION
The value is present in the `values.yaml` but doesn't appear in the actual deployment template. We need this value for our HPA implementation.