### PR TITLE
fix: allow drone server container port to be configurable 

### DIFF
--- a/charts/drone-runner-docker/templates/hpa.yaml
+++ b/charts/drone-runner-docker/templates/hpa.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ .Values.kind }}
     name: {{ include "drone-runner-docker.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/charts/drone-runner-docker/templates/service.yaml
+++ b/charts/drone-runner-docker/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.kind "Deployment" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       name: http
   selector:
     {{- include "drone-runner-docker.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/drone-runner-docker/templates/statefulset.yaml
+++ b/charts/drone-runner-docker/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.kind "Deployment" }}
+{{- if eq .Values.kind "StatefulSet" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "drone-runner-docker.fullname" . }}
   labels:
@@ -10,6 +10,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  serviceName: {{ include "drone-runner-docker.fullname" . }}
   selector:
     matchLabels:
       {{- include "drone-runner-docker.selectorLabels" . | nindent 6 }}
@@ -38,11 +39,18 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if  not .Values.persistance.enabled }}
       volumes:
         - name: {{ include "drone-runner-docker.fullname" . }}-cache
           emptyDir: {}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- else }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
         - name: dind
@@ -168,4 +176,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+  {{- if .Values.persistance.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ include "drone-runner-docker.fullname" . }}-cache
+    spec:
+      accessModes: [ {{ .Values.persistance.accessMode }} ]
+      storageClassName: {{ .Values.persistance.storageClass }}
+      resources:
+        requests:
+          storage: {{ .Values.persistance.size }}
+  {{- end }}
 {{- end }}

--- a/charts/drone-runner-docker/values.yaml
+++ b/charts/drone-runner-docker/values.yaml
@@ -2,6 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Choose kind of workload you want to use. StatefulSet or Deployment
+kind: StatefulSet
+
+persistance:
+  enabled: true
+  accessMode: ReadWriteOnce
+  storageClass: default
+  size: 32Gi
+
 # -- Mapping between IP and hostnames that will be injected as entries in the pod's hosts files
 # https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
 hostAliases: []
@@ -9,6 +18,7 @@ hostAliases: []
 #   hostnames:
 #   - gitea-127.0.0.1.sslip.io
 replicaCount: 1
+revisionHistoryLimit: 3
 
 ## The official drone docker runner image, change tag to use a different version.
 ## ref: https://hub.docker.com/r/drone/drone-runner-docker/tags/
@@ -24,9 +34,7 @@ image:
 ## Volumes here per the Pod spec's "volumes" section of the dind container
 ## Ref: https://kubernetes.io/docs/concepts/storage/volumes/
 ##
-extraVolumes:
-  - name: storage
-    emptyDir: {}
+extraVolumes: []
 ## If you have declared extra volumes, mount them here, per the Pod Container's
 ## "volumeMounts" section.
 ##
@@ -51,10 +59,7 @@ dind:
   ## If you have declared extra volumes, mount them here, per the Pod Container's
   ## "volumeMounts" section of dind container
   ##
-  extraVolumeMounts:
-    - name: storage
-      mountPath: /var/lib/docker
-      subPath: docker
+  extraVolumeMounts: []
   resources:
     {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -4,7 +4,7 @@ name: drone
 description: Drone is a self-service Continuous Delivery platform for busy development teams
 # TODO: Un-comment once we move back to apiVersion: v2.
 # type: application
-version: 0.6.5
+version: 0.6.6
 appVersion: 2.20.0
 kubeVersion: "^1.13.0-0"
 home: https://drone.io/

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.containerPort }}
+              containerPort: {{ .Values.service.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/drone/templates/deployment.yaml
+++ b/charts/drone/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/drone/values.yaml
+++ b/charts/drone/values.yaml
@@ -56,6 +56,7 @@ updateStrategy: {}
 service:
   type: ClusterIP
   port: 8080
+  containerPort: 8080
   annotations: {}
   nodePort:
 
@@ -188,6 +189,11 @@ env:
   ## Ref: https://docs.drone.io/installation/reference/drone-server-host/
   ##
   DRONE_SERVER_HOST: ""
+
+  ## Set the default container port where the server will run. This configuration needs to match with service.containerPort, see above
+  ##
+  DRONE_SERVER_HOST: ":8080"
+
   ## The protocol to pair with the value in DRONE_SERVER_HOST (http or https).
   ## Ref: https://docs.drone.io/installation/reference/drone-server-proto/
   ##


### PR DESCRIPTION
In some environments container port 80 is limited due to privileges issues like AKS. Make the server capable of listen in another port rather than 80.