### PR TITLE
Correct the drone-runnner-docker service's targetPort

### DIFF
--- a/charts/drone-runner-docker/templates/service.yaml
+++ b/charts/drone-runner-docker/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 3000
       protocol: TCP
       name: http
   selector:


### PR DESCRIPTION
The service for drone-runner-docker appears to have not been updated when the deployment was updated to host the runner's UI on port 3000.